### PR TITLE
Changing confusing task name 'css' to 'js'

### DIFF
--- a/examples/js/only-changed.js
+++ b/examples/js/only-changed.js
@@ -2,9 +2,10 @@ var gulp = require('gulp');
 var changed = require('gulp-changed');
 var uglify = require('gulp-uglify');
 
-gulp.task('css', function(){
+gulp.task('js', function(){
     return gulp.src('./src/*.js')
         .pipe(changed('./dist/'))
         .pipe(uglify())
         .pipe(gulp.dest('./dist/'));
 });
+


### PR DESCRIPTION
Fixing a typo where a gulp task that operates on *.js files was named 'css' instead of 'js'.